### PR TITLE
Exit cleanly on finished. Override auth and host keys.

### DIFF
--- a/changelog
+++ b/changelog
@@ -2,6 +2,8 @@ unreleased
     * Changed exit status to exit cleanly only if "finished" is typed.
     * Fix error from kill when no previous dropbear running.
     * Add authorized_keys file override.
+    * Add host keys override.
+    * Use wildcard to copy host key of any type: `dropbear_*_host_key`.
 
 2013-xx-xx v0.3.7
     * bugfix: #1 can start when an ssh server (dropbear) is already

--- a/changelog
+++ b/changelog
@@ -1,4 +1,5 @@
 unreleased
+    * Changed exit status to exit cleanly only if "finished" is typed.
     * Fix error from kill when no previous dropbear running.
 
 2013-xx-xx v0.3.7

--- a/changelog
+++ b/changelog
@@ -1,3 +1,6 @@
+unreleased
+    * Fix error from kill when no previous dropbear running.
+
 2013-xx-xx v0.3.7
     * bugfix: #1 can start when an ssh server (dropbear) is already
       running

--- a/changelog
+++ b/changelog
@@ -1,6 +1,7 @@
 unreleased
     * Changed exit status to exit cleanly only if "finished" is typed.
     * Fix error from kill when no previous dropbear running.
+    * Add authorized_keys file override.
 
 2013-xx-xx v0.3.7
     * bugfix: #1 can start when an ssh server (dropbear) is already

--- a/src/etc/early-ssh/early-ssh.conf.dist
+++ b/src/etc/early-ssh/early-ssh.conf.dist
@@ -27,3 +27,9 @@ TIMEOUT="600" # in seconds (empty means disabled, will wait forever)
 # PASSWD_OVERRIDE="/etc/early-ssh/passwd"
 # SHADOW_OVERRIDE="/etc/early-ssh/shadow"
 # GROUP_OVERRIDE="/etc/early-ssh/group"
+
+# By default early-ssh copies the root user's authorized_keys file. The
+# authorized_keys file may be overriden below. Please ensure the file is
+# owned by user or root, and not writable by group or others. (i.e. `chmod
+# 600 ...`)
+# AUTHKEY_OVERRIDE="/etc/early-ssh/authorized_keys"

--- a/src/etc/early-ssh/early-ssh.conf.dist
+++ b/src/etc/early-ssh/early-ssh.conf.dist
@@ -28,6 +28,10 @@ TIMEOUT="600" # in seconds (empty means disabled, will wait forever)
 # SHADOW_OVERRIDE="/etc/early-ssh/shadow"
 # GROUP_OVERRIDE="/etc/early-ssh/group"
 
+# By default early-ssh copies the host's dropbear host's keys. The directory
+# containing the host keys may be overriden below.
+# HOSTKEYDIR_OVERRIDE="/etc/early-ssh/"
+
 # By default early-ssh copies the root user's authorized_keys file. The
 # authorized_keys file may be overriden below. Please ensure the file is
 # owned by user or root, and not writable by group or others. (i.e. `chmod

--- a/src/usr/share/initramfs-tools/hooks/early_ssh
+++ b/src/usr/share/initramfs-tools/hooks/early_ssh
@@ -31,7 +31,6 @@ copy_exec /sbin/route sbin/
 cp -rp /etc/dropbear/dropbear_dss_host_key $DESTDIR/etc/dropbear/
 cp -rp /etc/dropbear/dropbear_rsa_host_key $DESTDIR/etc/dropbear/
 cp -rp /etc/localtime $DESTDIR/etc/
-[ -f /root/.ssh/authorized_keys ] && cp -rp /root/.ssh/authorized_keys $DESTDIR/root/.ssh/authorized_keys
 cp -rp /etc/login.defs $DESTDIR/etc/
 cp -rp /etc/early-ssh/early-ssh.conf $DESTDIR/etc/early-ssh/
 
@@ -50,6 +49,12 @@ shadow: files
 " > $DESTDIR/etc/nsswitch.conf
 
 . /etc/early-ssh/early-ssh.conf
+
+if [ "$AUTHKEY_OVERRIDE" != "" ]; then
+	cp -rp $AUTHKEY_OVERRIDE $DESTDIR/root/.ssh/authorized_keys
+else
+	[ -f /root/.ssh/authorized_keys ] && cp -rp /root/.ssh/authorized_keys $DESTDIR/root/.ssh/authorized_keys
+fi
 
 if [ "$PASSWD_OVERRIDE" != "" ]; then
 	cat $PASSWD_OVERRIDE >> $DESTDIR/etc/passwd

--- a/src/usr/share/initramfs-tools/hooks/early_ssh
+++ b/src/usr/share/initramfs-tools/hooks/early_ssh
@@ -28,8 +28,6 @@ copy_exec /sbin/route sbin/
 [ -f /usr/bin/scp ] && copy_exec /usr/bin/scp bin/
 
 # copy the configs
-cp -rp /etc/dropbear/dropbear_dss_host_key $DESTDIR/etc/dropbear/
-cp -rp /etc/dropbear/dropbear_rsa_host_key $DESTDIR/etc/dropbear/
 cp -rp /etc/localtime $DESTDIR/etc/
 cp -rp /etc/login.defs $DESTDIR/etc/
 cp -rp /etc/early-ssh/early-ssh.conf $DESTDIR/etc/early-ssh/
@@ -54,6 +52,12 @@ if [ "$AUTHKEY_OVERRIDE" != "" ]; then
 	cp -rp $AUTHKEY_OVERRIDE $DESTDIR/root/.ssh/authorized_keys
 else
 	[ -f /root/.ssh/authorized_keys ] && cp -rp /root/.ssh/authorized_keys $DESTDIR/root/.ssh/authorized_keys
+fi
+
+if [ "$HOSTKEYDIR_OVERRIDE" != "" ]; then
+	cp -rp $HOSTKEYDIR_OVERRIDE/dropbear_*_host_key $DESTDIR/etc/dropbear/
+else
+	cp -rp /etc/dropbear/dropbear_*_host_key $DESTDIR/etc/dropbear/
 fi
 
 if [ "$PASSWD_OVERRIDE" != "" ]; then

--- a/src/usr/share/initramfs-tools/scripts/local-top/early_ssh
+++ b/src/usr/share/initramfs-tools/scripts/local-top/early_ssh
@@ -19,9 +19,11 @@ version="0.3.7-testing"
 
 . /etc/early-ssh/early-ssh.conf
 
+exitcode=1
+
 if [ "$DISABLED" == 1 ]; then
 	echo "*** early-ssh disabled in config - exiting."
-	exit 0
+	exit $exitcode
 fi
 
 # kill any previously existing dropbear ssh server instances
@@ -113,7 +115,10 @@ while [ /bin/true ]; do
 	[ "$?" == 0 ] && break
 	
 	# if this file exists, the user have run "finished"
-	[ -f /tmp/early_ssh.finished ] && break
+	if [ -f /tmp/early_ssh.finished ]; then
+		exitcode=0
+		break
+	fi
 	
 	# check for the timeout, if it is enabled
 	if [ "$TIMEOUT" != "" ]; then
@@ -133,4 +138,4 @@ kill `pidof dropbear`
 # shut down the networking
 ifconfig $INTERFACE down
 
-exit 0
+exit $exitcode

--- a/src/usr/share/initramfs-tools/scripts/local-top/early_ssh
+++ b/src/usr/share/initramfs-tools/scripts/local-top/early_ssh
@@ -25,7 +25,9 @@ if [ "$DISABLED" == 1 ]; then
 fi
 
 # kill any previously existing dropbear ssh server instances
-kill `pidof dropbear`
+if pidof -q dropbear; then
+	kill `pidof dropbear`
+fi
 
 # give a short summary of the current configuration and find out the
 # interface by MAC address (if given that way)


### PR DESCRIPTION
- Have early-ssh exit with a status of 0 only if "finished" was typed in the SSH session. This potentially allows the init process to tell if early-ssh was used, times out, or exited from the local terminal.
- Add override for authorized keys file.
- Add override for directory containing dropbear host keys.
- Support edcsa, ed25519, and future host key types.

